### PR TITLE
Added touch-action property

### DIFF
--- a/src/HoverComponent.js
+++ b/src/HoverComponent.js
@@ -51,7 +51,8 @@ export class ProgressButton extends Component {
 
   render() {
     let style ={
-        background:`linear-gradient(to top, #51b7e6 0%, #51b7e6 ${this.state.progress * 100}%, transparent ${this.state.progress * 100}%, transparent 100%)`
+        background: `linear-gradient(to top, #51b7e6 0%, #51b7e6 ${this.state.progress * 100}%, transparent ${this.state.progress * 100}%, transparent 100%)`,
+        touchAction: 'none'
     };
 
     return (


### PR DESCRIPTION
Partially fixes #11

The `touch-action` CSS property set to `none` fixes the issue for Chrome/Edge.

Firefox Android does not support Pointer events : https://caniuse.com/#feat=pointer, so... won't fix?